### PR TITLE
fix dhttp wrap comment error

### DIFF
--- a/net/dhttp/wrap.go
+++ b/net/dhttp/wrap.go
@@ -44,7 +44,7 @@ func CheckWrap(toWrap interface{}) error {
 		return fmt.Errorf("params out 3 must be interface %v", toWrap)
 	}
 	if !wt.Out(2).Implements(errInterface) {
-		return fmt.Errorf("params out 4 must be error %v", toWrap)
+		return fmt.Errorf("params out 3 must be error %v", toWrap)
 	}
 	return nil
 }


### PR DESCRIPTION
CheckWrap使用两步检查第三个参数是否为error类型，最后注释描述有误
Signed-off-by: zhengdelun <xszhengdelun@gmail.com>