### PR TITLE
fix dogrpc test build error

### DIFF
--- a/net/dogrpc/dog_client_test.go
+++ b/net/dogrpc/dog_client_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestDogClient(t *testing.T) {
-	d := gd.Default()
-	c := d.NewRpcClient(time.Duration(500*time.Millisecond), 0)
+	c := gd.NewRpcClient(time.Duration(500*time.Millisecond), 0)
 	c.AddAddr(network.GetLocalIP() + ":10241")
 
 	b := &struct {

--- a/net/dogrpc/dog_server_test.go
+++ b/net/dogrpc/dog_server_test.go
@@ -39,7 +39,7 @@ func TestDogServer(t *testing.T) {
 		return
 	}
 
-	err := d.RpcServer.Run(10241)
+	err := d.RpcServer.Start()
 	if err != nil {
 		t.Logf("Error occurs, error = %s", err.Error())
 		return

--- a/net/dogrpc/rpc_client_test.go
+++ b/net/dogrpc/rpc_client_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestRpcClient(t *testing.T) {
-	d := gd.Default()
-	c := d.NewRpcClient(time.Duration(500*time.Millisecond), 0)
+	c := gd.NewRpcClient(time.Duration(500*time.Millisecond), 0)
 	c.AddAddr(network.GetLocalIP() + ":10241")
 
 	body := []byte("How are you?")

--- a/net/dogrpc/rpc_server_test.go
+++ b/net/dogrpc/rpc_server_test.go
@@ -20,7 +20,7 @@ func TestRpcServer(t *testing.T) {
 		return code, resp
 	})
 
-	err := d.Run(10241)
+	err := d.Start()
 	if err != nil {
 		t.Logf("Error occurs, derror = %s", err.Error())
 		return


### PR DESCRIPTION
修复go test的编译错误
```
# github.com/chuck1024/gd/net/dogrpc_test [github.com/chuck1024/gd/net/dogrpc.test]
./dog_client_test.go:18:8: d.NewRpcClient undefined (type *gd.Engine has no field or method NewRpcClient)
./dog_server_test.go:42:20: d.RpcServer.Run undefined (type *dogrpc.RpcServer has no field or method Run)
./rpc_client_test.go:17:8: d.NewRpcClient undefined (type *gd.Engine has no field or method NewRpcClient)
./rpc_server_test.go:23:10: d.Run undefined (type *dogrpc.RpcServer has no field or method Run)
```
Signed-off-by: zhengdelun <xszhengdelun@gmail.com>